### PR TITLE
GitHub Discussionsにコメントがあった際にSlackへの通知を行うworkflowのテンプレートを追加

### DIFF
--- a/workflow-templates/discussion-comment-notice.properties.json
+++ b/workflow-templates/discussion-comment-notice.properties.json
@@ -1,0 +1,8 @@
+{
+  "name": "discussion-comment-notice",
+  "description": "Notify Slack when a discussion comment is created.",
+  "iconName": "example-icon",
+  "categories": [
+      "utilities"
+  ]
+}

--- a/workflow-templates/discussion-comment-notice.yml
+++ b/workflow-templates/discussion-comment-notice.yml
@@ -5,6 +5,6 @@ on:
 jobs:
   discussion_commented:
     if: github.event.discussion && github.event.comment
-    uses: route06/actions/.github/workflows/_discussions-comment-notice.yml@v1
+    uses: route06/actions/.github/workflows/gh_discussion_comment_to_slack.yml@v2
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_GHD_WEBHOOK_URL }}

--- a/workflow-templates/discussion-comment-notice.yml
+++ b/workflow-templates/discussion-comment-notice.yml
@@ -1,0 +1,13 @@
+on:
+  discussion_comment:
+    types: [created]
+
+jobs:
+  discussion_commented:
+    if: github.event.discussion && github.event.comment
+    uses: route06/actions/.github/workflows/_discussions-comment-notice.yml@v1
+    secrets:
+      # NOTE: このコメントは設定が終わり次第不要なため削除してください！
+      # Slackへの通知には、1. Slack AppでWebhook URLを作成 2. GitHubのRepository SecretsにWebhook URLを追加 の2つの設定が必要です。以下を参考に設定してください。
+      # https://docs.route06.co.jp/docs/knowledge/contents/github-notification-setting-for-slack/#discussionに対してのコメントの通知も受け取りたい場合
+      slack-webhook-url: ${{ secrets.SLACK_GHD_WEBHOOK_URL }}

--- a/workflow-templates/discussion-comment-notice.yml
+++ b/workflow-templates/discussion-comment-notice.yml
@@ -7,7 +7,4 @@ jobs:
     if: github.event.discussion && github.event.comment
     uses: route06/actions/.github/workflows/_discussions-comment-notice.yml@v1
     secrets:
-      # NOTE: このコメントは設定が終わり次第不要なため削除してください！
-      # Slackへの通知には、1. Slack AppでWebhook URLを作成 2. GitHubのRepository SecretsにWebhook URLを追加 の2つの設定が必要です。以下を参考に設定してください。
-      # https://docs.route06.co.jp/docs/knowledge/contents/github-notification-setting-for-slack/#discussionに対してのコメントの通知も受け取りたい場合
       slack-webhook-url: ${{ secrets.SLACK_GHD_WEBHOOK_URL }}


### PR DESCRIPTION
GitHubのStarter Workflowという機能を利用し、GitHub Discussionsにコメントがあった際にSlackへの通知を行うworkflowのテンプレートを追加しました。

これはGUI上でワークフローをセットアップ可能になるようです。おそらく以下に追加される想定です。

https://github.com/route06/.github/actions/new

この処理は社内でよく使われることが多いため、GUI上でセットアップできれば非開発職の方でも設定しやすくなるのではないかと考え今回追加してみました。

## 設定内容

内容は以下を参考にしています。

https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization