### PR TITLE
fix: iconNameを省略する

### DIFF
--- a/workflow-templates/discussion-comment-notice.properties.json
+++ b/workflow-templates/discussion-comment-notice.properties.json
@@ -1,7 +1,6 @@
 {
   "name": "discussion-comment-notice",
   "description": "Notify Slack when a discussion comment is created.",
-  "iconName": "example-icon",
   "categories": [
       "utilities"
   ]


### PR DESCRIPTION
https://github.com/route06/.github/pull/2 をマージしたところ、想定通りワークフロー作成画面でstarter workflowが表示されるようになりました 👍🏻 

![スクリーンショット 2024-02-19 12 15 01](https://github.com/route06/.github/assets/31152321/b32d8b78-a9da-4cac-9bb6-aec69198803b)

ref: https://github.com/route06/.github/actions/new

ただ、アイコン画像の参照に失敗しています。ここは省略可能であり、ゆくゆくは設定しても良いかもですが、必ず設定しなくてはいけないものでもないため、一度取り除きます。
