### PR TITLE
GitHub スターターワークフローを追加する

### DIFF
--- a/workflow-templates/create_issue.properties.json
+++ b/workflow-templates/create_issue.properties.json
@@ -1,0 +1,7 @@
+{
+  "name": "Create a issue",
+  "description": "Here is a sample workflow for creating one issue.",
+  "categories": [
+    "utilities"
+  ]
+}

--- a/workflow-templates/create_issue.yml
+++ b/workflow-templates/create_issue.yml
@@ -1,0 +1,44 @@
+# NOTE: 適当な workflow 名にして下さい。Actions タブ左側に表示されます。
+# 例: https://github.com/route06/general/actions
+name: Create a sample issue
+
+on:
+  workflow_dispatch:
+  schedule:
+    # NOTE: Issueを作成するタイミングに合わせて修正してください。
+    # 例:
+    # 毎週水曜13:00に作成する → cron: "0 4 * * wed"
+    # 毎週月曜8:00に作成する → cron: "0 23 * * sun"
+    # ref: https://docs.github.com/ja/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule
+    - cron: "0 4 * * wed"
+
+jobs:
+  get_date:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Get today
+        id: get_today
+        # NOTE: この例では今日の日付が Issue タイトルに使われます。例: 2024/09/13
+        run: |
+          echo "today=$(date +%Y/%m/%d)" >> "$GITHUB_OUTPUT"
+    outputs:
+      today: ${{ steps.get_today.outputs.today }}
+
+  create_issue:
+    needs: get_date
+    uses: route06/actions/.github/workflows/create_gh_issue.yml@v2
+    permissions:
+      contents: read
+      issues: write
+    with:
+      # NOTE: タイトルを修正してください。以下は、「yyyy/mm/dd Sample TODO」となります。
+      title: ${{ needs.get_date.outputs.today }} Sample TODO
+      # NOTE: 本文に利用するテンプレートファイルを作成し、パスを指定してください。
+      # 以下は、リポジトリに "_templates/sample_todo.md" というファイルがある想定です。
+      # ファイルが見つからない場合、本文が空の Issue が作成されます。
+      description_template_path: _templates/sample_todo.md
+      # NOTE: [任意] アサインしたい人を設定して下さい。不要ならこの行自体を削除して下さい。
+      assignees: alice,bob
+      # NOTE: [任意] ラベルを設定して下さい。不要ならこの行自体を削除して下さい。
+      labels: bug,wontfix

--- a/workflow-templates/create_weekly_meeting_discussion.yml
+++ b/workflow-templates/create_weekly_meeting_discussion.yml
@@ -19,7 +19,6 @@ jobs:
       # 金曜日に実施する場合は target_day: friday となります。
       target_day: wednesday
   
-  # GitHub Discussion を作成する
   create_discussion:
     needs: [calc_next_weekly_date]
     uses: route06/actions/.github/workflows/create_gh_discussion.yml@v2
@@ -36,49 +35,3 @@ jobs:
       # 以下は、リポジトリに "_templates/weekly_meeting_discussion/body.md" というファイルがある想定です。
       # ファイルが見つからない場合、本文が空のDiscussionが作成されます。
       description_template_path: _templates/weekly_meeting_discussion/body.md
-
-  # [任意] 作成した Discussion にコメント1を追加する
-  # NOTE: 不要なら削除して下さい。
-  add_comment1:
-    needs: create_discussion
-    uses: route06/actions/.github/workflows/add_discussion_comment.yml@v2
-    permissions:
-      contents: read
-      discussions: write
-    with:
-      discussion_id: ${{ needs.create_discussion.outputs.discussion_id }}
-      # NOTE: 1番目のコメントに利用するテンプレートファイルを作成し、パスを指定してください。
-      # 以下は、リポジトリに "_templates/weekly_meeting_discussion/comment1.md" というファイルがある想定です。
-      # ファイルが見つからない場合、本文が空のコメントが追加されます。
-      comment_template_path: _templates/weekly_meeting_discussion/comment1.md
-
-  # [任意] 追加したコメント1に返信する
-  # NOTE: 不要なら削除して下さい。
-  reply_to_comment1:
-    needs: add_comment1
-    uses: route06/actions/.github/workflows/add_discussion_comment.yml@v2
-    permissions:
-      contents: read
-      discussions: write
-    with:
-      discussion_id: ${{ needs.add_comment1.outputs.discussion_id }}
-      # NOTE: コメント1への返信に利用するテンプレートファイルを作成し、パスを指定してください。
-      # 以下は、リポジトリに "_templates/weekly_meeting_discussion/comment1_reply1.md" というファイルがある想定です。
-      # ファイルが見つからない場合、本文が空の返信が追加されます。
-      comment_template_path: _templates/weekly_meeting_discussion/comment1_reply1.md
-      reply_to_comment_id: ${{ needs.add_comment1.outputs.comment_id }}
-
-  # [任意] 作成した Discussion にコメント2を追加する
-  # NOTE: 不要なら削除して下さい。
-  add_comment2:
-    needs: add_comment1
-    uses: route06/actions/.github/workflows/add_discussion_comment.yml@v2
-    permissions:
-      contents: read
-      discussions: write
-    with:
-      discussion_id: ${{ needs.add_comment1.outputs.discussion_id }}
-      # NOTE: 2番目のコメントに利用するテンプレートファイルを作成し、パスを指定してください。
-      # 以下は、リポジトリに "_templates/weekly_meeting_discussion/comment2.md" というファイルがある想定です。
-      # ファイルが見つからない場合、本文が空のコメントが追加されます。
-      comment_template_path: _templates/weekly_meeting_discussion/comment2.md

--- a/workflow-templates/create_weekly_meeting_discussion.yml
+++ b/workflow-templates/create_weekly_meeting_discussion.yml
@@ -19,6 +19,7 @@ jobs:
       # 金曜日に実施する場合は target_day: friday となります。
       target_day: wednesday
   
+  # GitHub Discussion を作成する
   create_discussion:
     needs: [calc_next_weekly_date]
     uses: route06/actions/.github/workflows/create_gh_discussion.yml@v2
@@ -35,3 +36,49 @@ jobs:
       # 以下は、リポジトリに "_templates/weekly_meeting_discussion/body.md" というファイルがある想定です。
       # ファイルが見つからない場合、本文が空のDiscussionが作成されます。
       description_template_path: _templates/weekly_meeting_discussion/body.md
+
+  # [任意] 作成した Discussion にコメント1を追加する
+  # NOTE: 不要なら削除して下さい。
+  add_comment1:
+    needs: create_discussion
+    uses: route06/actions/.github/workflows/add_discussion_comment.yml@v2
+    permissions:
+      contents: read
+      discussions: write
+    with:
+      discussion_id: ${{ needs.create_discussion.outputs.discussion_id }}
+      # NOTE: 1番目のコメントに利用するテンプレートファイルを作成し、パスを指定してください。
+      # 以下は、リポジトリに "_templates/weekly_meeting_discussion/comment1.md" というファイルがある想定です。
+      # ファイルが見つからない場合、本文が空のコメントが追加されます。
+      comment_template_path: _templates/weekly_meeting_discussion/comment1.md
+
+  # [任意] 追加したコメント1に返信する
+  # NOTE: 不要なら削除して下さい。
+  reply_to_comment1:
+    needs: add_comment1
+    uses: route06/actions/.github/workflows/add_discussion_comment.yml@v2
+    permissions:
+      contents: read
+      discussions: write
+    with:
+      discussion_id: ${{ needs.add_comment1.outputs.discussion_id }}
+      # NOTE: コメント1への返信に利用するテンプレートファイルを作成し、パスを指定してください。
+      # 以下は、リポジトリに "_templates/weekly_meeting_discussion/comment1_reply1.md" というファイルがある想定です。
+      # ファイルが見つからない場合、本文が空の返信が追加されます。
+      comment_template_path: _templates/weekly_meeting_discussion/comment1_reply1.md
+      reply_to_comment_id: ${{ needs.add_comment1.outputs.comment_id }}
+
+  # [任意] 作成した Discussion にコメント2を追加する
+  # NOTE: 不要なら削除して下さい。
+  add_comment2:
+    needs: add_comment1
+    uses: route06/actions/.github/workflows/add_discussion_comment.yml@v2
+    permissions:
+      contents: read
+      discussions: write
+    with:
+      discussion_id: ${{ needs.add_comment1.outputs.discussion_id }}
+      # NOTE: 2番目のコメントに利用するテンプレートファイルを作成し、パスを指定してください。
+      # 以下は、リポジトリに "_templates/weekly_meeting_discussion/comment2.md" というファイルがある想定です。
+      # ファイルが見つからない場合、本文が空のコメントが追加されます。
+      comment_template_path: _templates/weekly_meeting_discussion/comment2.md

--- a/workflow-templates/create_weekly_meeting_discussion_with_comments.properties.json
+++ b/workflow-templates/create_weekly_meeting_discussion_with_comments.properties.json
@@ -1,0 +1,7 @@
+{
+  "name": "Create weekly meeting discussion with comments",
+  "description": "Create a discussion with comments for weekly meeting",
+  "categories": [
+    "utilities"
+  ]
+}

--- a/workflow-templates/create_weekly_meeting_discussion_with_comments.yml
+++ b/workflow-templates/create_weekly_meeting_discussion_with_comments.yml
@@ -1,0 +1,84 @@
+name: Create weekly meeting discussion with comments
+
+on:
+  workflow_dispatch:
+  schedule:
+    # NOTE: Discussionを作成するタイミングに合わせて修正してください。
+    # 例:
+    # 毎週水曜13:00に作成する → cron: "0 4 * * wed"
+    # 毎週月曜8:00に作成する → cron: "0 23 * * sun"
+    # ref: https://docs.github.com/ja/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule
+    - cron: "0 4 * * wed"
+
+jobs:
+  calc_next_weekly_date:
+    uses: route06/actions/.github/workflows/calc_next_date.yml@v2
+    with:
+      interval: weekly
+      # NOTE: ミーティング実施曜日を指定してください。
+      # 金曜日に実施する場合は target_day: friday となります。
+      target_day: wednesday
+  
+  # GitHub Discussion を作成する
+  create_discussion:
+    needs: [calc_next_weekly_date]
+    uses: route06/actions/.github/workflows/create_gh_discussion.yml@v2
+    with:
+      # NOTE: タイトルを修正してください。以下は、「yyyy/mm/dd タイトル」となります。
+      # 「yyyy/mm/dd 週次定例」としたい場合は title: ${{ needs.calc_next_weekly_date.outputs.next_date }} 週次定例 となります。
+      title: ${{ needs.calc_next_weekly_date.outputs.next_date }} タイトル
+      # NOTE: 設定したいカテゴリに合わせて修正してください。
+      # 指定するのは、各カテゴリを選択した時のURL末尾の文字列です。
+      # https://github.com/<org>/<repo>/discussions/categories/meeting-notes
+      # カテゴリ Meeting notesの場合は、上記のURLのように "meeting-notes" となるため category_slug: meeting-notes となります。
+      category_slug: ideas
+      # NOTE: 本文に利用するテンプレートファイルを作成し、パスを指定してください。
+      # 以下は、リポジトリに "_templates/weekly_meeting_discussion/body.md" というファイルがある想定です。
+      # ファイルが見つからない場合、本文が空のDiscussionが作成されます。
+      description_template_path: _templates/weekly_meeting_discussion/body.md
+
+  # [任意] 作成した Discussion にコメント1を追加する
+  # NOTE: 不要なら削除して下さい。
+  add_comment1:
+    needs: create_discussion
+    uses: route06/actions/.github/workflows/add_discussion_comment.yml@v2
+    permissions:
+      contents: read
+      discussions: write
+    with:
+      discussion_id: ${{ needs.create_discussion.outputs.discussion_id }}
+      # NOTE: 1番目のコメントに利用するテンプレートファイルを作成し、パスを指定してください。
+      # 以下は、リポジトリに "_templates/weekly_meeting_discussion/comment1.md" というファイルがある想定です。
+      # ファイルが見つからない場合、本文が空のコメントが追加されます。
+      comment_template_path: _templates/weekly_meeting_discussion/comment1.md
+
+  # [任意] 追加したコメント1に返信する
+  # NOTE: 不要なら削除して下さい。
+  reply_to_comment1:
+    needs: add_comment1
+    uses: route06/actions/.github/workflows/add_discussion_comment.yml@v2
+    permissions:
+      contents: read
+      discussions: write
+    with:
+      discussion_id: ${{ needs.add_comment1.outputs.discussion_id }}
+      # NOTE: コメント1への返信に利用するテンプレートファイルを作成し、パスを指定してください。
+      # 以下は、リポジトリに "_templates/weekly_meeting_discussion/comment1_reply1.md" というファイルがある想定です。
+      # ファイルが見つからない場合、本文が空の返信が追加されます。
+      comment_template_path: _templates/weekly_meeting_discussion/comment1_reply1.md
+      reply_to_comment_id: ${{ needs.add_comment1.outputs.comment_id }}
+
+  # [任意] 作成した Discussion にコメント2を追加する
+  # NOTE: 不要なら削除して下さい。
+  add_comment2:
+    needs: add_comment1
+    uses: route06/actions/.github/workflows/add_discussion_comment.yml@v2
+    permissions:
+      contents: read
+      discussions: write
+    with:
+      discussion_id: ${{ needs.add_comment1.outputs.discussion_id }}
+      # NOTE: 2番目のコメントに利用するテンプレートファイルを作成し、パスを指定してください。
+      # 以下は、リポジトリに "_templates/weekly_meeting_discussion/comment2.md" というファイルがある想定です。
+      # ファイルが見つからない場合、本文が空のコメントが追加されます。
+      comment_template_path: _templates/weekly_meeting_discussion/comment2.md


### PR DESCRIPTION
## 変更概要

### "Create weekly meeting discussion" を更新

https://github.com/route06/actions/pull/72 で追加された [add_discussion_comment.yml](https://github.com/route06/actions/blob/v2.4.0/.github/workflows/add_discussion_comment.yml) を使ったジョブを追加しました。

**動作確認結果:**

* サンプルコード
    * https://github.com/masutaka/sandbox/blob/e5aba50a51d13e1a26f4bb025e59f298fbefae65/.github/workflows/create_discussion2.yml
* 実行した GitHub Action
    * https://github.com/masutaka/sandbox/actions/runs/10844975989
* 作成された GitHub Discussion
    * https://github.com/masutaka/sandbox/discussions/68

### "Create a issue" を追加

https://github.com/route06/actions/pull/73 で追加された [create_gh_issue.yml](https://github.com/route06/actions/blob/v2.4.0/.github/workflows/create_gh_issue.yml) を使ったジョブを追加しました。

**動作確認結果:**

* サンプルコード
    * https://github.com/masutaka/sandbox/blob/e743db5e7b532aebf8b1a6c5915f73c1c9bdbecf/.github/workflows/create_issue2.yml
* 実行した GitHub Action
    * https://github.com/masutaka/sandbox/actions/runs/10844917134
* 作成された GitHub Issue
    * https://github.com/masutaka/sandbox/issues/67
